### PR TITLE
support generic less config - closes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,3 +200,25 @@ The `context` argument will contain the following properties:
 - `pluginConfig` - The configuration passed to the `lasso-less` plugin when registered
 - `lasso` - The Lasso.js instance
 - `lassoContext` - The Lasso.js context object
+
+## Less Configuration
+
+You can pass less configuration options in `lessConfig` of the `config` object. These options will be passed 
+directly to less. For example:
+
+```js
+require('lasso').configure({
+    ...
+    plugins: [
+        {
+            plugin: 'lasso-less',
+            config: {
+                lessConfig: {
+                    strictMath: true,
+                    strictUnits: true
+                }
+            }
+        }
+    ]
+});
+```

--- a/lib/dependency-less.js
+++ b/lib/dependency-less.js
@@ -1,3 +1,4 @@
+var assign = require('lodash/object/assign');
 var nodePath = require('path');
 var logger = require('raptor-logging').logger(module);
 var loader = require('./util/less-loader');
@@ -122,6 +123,9 @@ module.exports = function create(config, lasso) {
                     filename: 'lasso.less',
                     paths: [process.cwd()]
                 };
+                if (config.lessConfig) {
+                    assign(parseConfig, config.lessConfig);
+                }
 
                 less.render(
                     lessCode,

--- a/package.json
+++ b/package.json
@@ -1,49 +1,50 @@
 {
-    "name": "lasso-less",
-    "description": "Lasso.js plugin to support compilation of less dependencies",
-    "keywords": [
-        "lasso",
-        "lasso-plugin",
-        "less"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/lasso-js/lasso-less.git"
-    },
-    "scripts": {
-        "test": "node_modules/.bin/mocha --ui bdd --reporter spec ./test && node_modules/.bin/jshint lib/**/*.js"
-    },
-    "author": "Patrick Steele-Idem <pnidem@gmail.com>",
-    "contributors": [
-        "Patrick Steele-Idem <pnidem@gmail.com>",
-        "Phillip Gates-Idem <phillip.idem@gmail.com>",
-        "Mahdi Pedramrazi <pedramphp@gmail.com>"
-    ],
-    "maintainers": [
-        "Patrick Steele-Idem <pnidem@gmail.com>",
-        "Mahdi Pedramrazi <pedramphp@gmail.com>"
-    ],
-    "dependencies": {
-        "async": "^0.9.0",
-        "less": "^2.0.0",
-        "raptor-async": "^1.0.3",
-        "raptor-logging": "^1.0.5",
-        "raptor-modules": "^1.0.18",
-        "raptor-polyfill": "^1.0.2",
-        "raptor-util": "^1.0.10",
-        "resolve-from": "^1.0.0"
-    },
-    "devDependencies": {
-        "chai": "^1.9.1",
-        "jshint": "^2.5.5",
-        "mocha": "^1.21.4",
-        "lasso": "^1.8.4"
-    },
-    "license": "Apache License v2.0",
-    "bin": {},
-    "main": "./lib/index.js",
-    "publishConfig": {
-        "registry": "https://registry.npmjs.org/"
-    },
-    "version": "2.1.1"
+  "name": "lasso-less",
+  "description": "Lasso.js plugin to support compilation of less dependencies",
+  "keywords": [
+    "lasso",
+    "lasso-plugin",
+    "less"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lasso-js/lasso-less.git"
+  },
+  "scripts": {
+    "test": "node_modules/.bin/mocha --ui bdd --reporter spec ./test && node_modules/.bin/jshint lib/**/*.js"
+  },
+  "author": "Patrick Steele-Idem <pnidem@gmail.com>",
+  "contributors": [
+    "Patrick Steele-Idem <pnidem@gmail.com>",
+    "Phillip Gates-Idem <phillip.idem@gmail.com>",
+    "Mahdi Pedramrazi <pedramphp@gmail.com>"
+  ],
+  "maintainers": [
+    "Patrick Steele-Idem <pnidem@gmail.com>",
+    "Mahdi Pedramrazi <pedramphp@gmail.com>"
+  ],
+  "dependencies": {
+    "async": "^0.9.0",
+    "less": "^2.0.0",
+    "lodash": "^3.10.1",
+    "raptor-async": "^1.0.3",
+    "raptor-logging": "^1.0.5",
+    "raptor-modules": "^1.0.18",
+    "raptor-polyfill": "^1.0.2",
+    "raptor-util": "^1.0.10",
+    "resolve-from": "^1.0.0"
+  },
+  "devDependencies": {
+    "chai": "^1.9.1",
+    "jshint": "^2.5.5",
+    "mocha": "^1.21.4",
+    "lasso": "^1.8.4"
+  },
+  "license": "Apache License v2.0",
+  "bin": {},
+  "main": "./lib/index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "version": "2.1.1"
 }

--- a/test/fixtures/less-config.expected.css
+++ b/test/fixtures/less-config.expected.css
@@ -1,0 +1,7 @@
+/******************************************/
+/* BEGIN "test/fixtures/less-config.less" */
+.foo {
+  width: calc(100% - 50px);
+}
+/* END   "test/fixtures/less-config.less" */
+/******************************************/

--- a/test/fixtures/less-config.less
+++ b/test/fixtures/less-config.less
@@ -1,0 +1,3 @@
+.foo {
+    width: calc(100% - 50px);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -432,8 +432,7 @@ describe('lasso-less' , function() {
                     plugin: lessPlugin,
                     config: {
                         lessConfig: {
-                            strictMath: true,
-                            strictUnits: true
+                            strictMath: true
                         }
                     }
                 }

--- a/test/test.js
+++ b/test/test.js
@@ -420,4 +420,43 @@ describe('lasso-less' , function() {
             });
     });
 
+
+    it('should support less config', function(done) {
+
+        var myLasso = lasso.create({
+            fingerprintsEnabled: false,
+            outputDir: nodePath.join(__dirname, 'static'),
+            bundlingEnabled: true,
+            plugins: [
+                {
+                    plugin: lessPlugin,
+                    config: {
+                        lessConfig: {
+                            strictMath: true,
+                            strictUnits: true
+                        }
+                    }
+                }
+            ]
+        });
+
+        myLasso.lassoPage({
+                name: 'testPage',
+                dependencies: [
+                    nodePath.join(__dirname, 'fixtures/less-config.less')
+                ]
+            },
+            function(err, lassoPageResult) {
+                if (err) {
+                    return done(err);
+                }
+
+                var actual = fs.readFileSync(nodePath.join(__dirname, 'static/testPage.css'), {encoding: 'utf8'});
+                var expected = fs.readFileSync(nodePath.join(__dirname, 'fixtures/less-config.expected.css'), {encoding: 'utf8'});
+                fs.writeFileSync(nodePath.join(__dirname, 'fixtures/less-config.actual.css'), actual, {encoding: 'utf8'});
+                expect(actual).to.equal(expected);
+                done();
+            });
+    });
+
 });


### PR DESCRIPTION
Added `config.lessConfig`, some brief documentation,  and a test case to demonstrate it working with strictMath. I looked at testing some other configuration too, but those are less obvious to test, so I left them out for now. I brought in lodash to extend the parseConfig object. Let me know of any changes if needed.