### PR TITLE
Add support for webpack style node require resolution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 node_js:
-- "4"
 - "6"
 - "8"
+- "10"
 language: node_js
 script: "npm test"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can use `@import` (e.g., `@import "foo.less";`) inside a Less file to import
 }
 ```
 
-The `lasso-less` plugin also supports resolving Less files using the Node.js module resolver. If you need to include a Less file found in an installed module then you can prefix an import with `require:`. For example, given the following directory structure:
+The `lasso-less` plugin also supports resolving Less files using the Node.js module resolver. If you need to include a Less file found in an installed module then you can prefix an import with `require:` or `~`. For example, given the following directory structure:
 
 ```
 ./
@@ -121,6 +121,8 @@ _using `@import`:_
 
 ```css
 @import "require: my-module/foo.less";
+// or
+@import "~my-module/foo.less";
 ```
 
 _using `browser.json`:_

--- a/src/util/less-parser.js
+++ b/src/util/less-parser.js
@@ -1,6 +1,6 @@
 var tokenizerRegExp = /\@import\s+(?:"((?:\\"|[^"])*)"|'((?:\\'|[^'])*)')\s*;|url\(\s*"((?:\\"|[^"])*)"\s*\)|url\(\s*'((?:\\'|[^'])*)'\s*\)|url\(([^\)]*)\)|\/\*|\*\/|\/\/|\n|\r|\\\\|\\"|"/g;
 var nodePath = require('path');
-var requireRegExp = /^require\s*:\s*(.+)$/;
+var requireRegExp = /^(?:require\s*:\s*|~)(.+)$/;
 var resolveFrom = require('resolve-from');
 
 function encodeSpecialURLChar(c) {

--- a/test/autotests/plugin/import-require-alias/bar/bar.less
+++ b/test/autotests/plugin/import-require-alias/bar/bar.less
@@ -1,0 +1,6 @@
+@import "~installed/mixins.less";
+
+.bar {
+    color: @bar-color;
+    .bordered;
+}

--- a/test/autotests/plugin/import-require-alias/bar/browser.json
+++ b/test/autotests/plugin/import-require-alias/bar/browser.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": [
+        "bar.less"
+    ]
+}

--- a/test/autotests/plugin/import-require-alias/baz/baz.less
+++ b/test/autotests/plugin/import-require-alias/baz/baz.less
@@ -1,0 +1,6 @@
+@import "~installed/mixins.less";
+
+.baz {
+    color: @bar-color;
+    .bordered;
+}

--- a/test/autotests/plugin/import-require-alias/baz/browser.json
+++ b/test/autotests/plugin/import-require-alias/baz/browser.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": [
+        "baz.less"
+    ]
+}

--- a/test/autotests/plugin/import-require-alias/browser.json
+++ b/test/autotests/plugin/import-require-alias/browser.json
@@ -1,0 +1,16 @@
+{
+    "dependencies": [
+        "less-import: variables.less",
+        "main.less",
+        "./baz/browser.json"
+    ],
+
+    "async": {
+        "foo": [
+            "./foo/browser.json"
+        ],
+        "bar": [
+            "./bar/browser.json"
+        ]
+    }
+}

--- a/test/autotests/plugin/import-require-alias/expected-async.css
+++ b/test/autotests/plugin/import-require-alias/expected-async.css
@@ -1,0 +1,33 @@
+/*********************************************************************/
+/* BEGIN "test/autotests/plugin/import-require-alias/variables.less" */
+/* END   "test/autotests/plugin/import-require-alias/variables.less" */
+/*********************************************************************/
+/*******************************************************************/
+/* BEGIN "test/autotests/plugin/import-require-alias/foo/foo.less" */
+/* @import "~installed/mixins.less"; */
+/*-----------------------------------------------------------------------------------------*/
+/* + BEGIN "test/autotests/plugin/import-require-alias/node_modules/installed/mixins.less" */
+.bordered {
+  border-top: dotted 1px purple;
+  border-bottom: solid 2px purple;
+}
+/* + END   "test/autotests/plugin/import-require-alias/node_modules/installed/mixins.less" */
+/*-----------------------------------------------------------------------------------------*/
+.foo {
+  color: green;
+  border-top: dotted 1px purple;
+  border-bottom: solid 2px purple;
+}
+/* END   "test/autotests/plugin/import-require-alias/foo/foo.less" */
+/*******************************************************************/
+/*******************************************************************/
+/* BEGIN "test/autotests/plugin/import-require-alias/bar/bar.less" */
+/* @import "~installed/mixins.less"; (skipped, already imported) */
+.bar {
+  color: blue;
+  border-top: dotted 1px purple;
+  border-bottom: solid 2px purple;
+}
+/* END   "test/autotests/plugin/import-require-alias/bar/bar.less" */
+/*******************************************************************/
+

--- a/test/autotests/plugin/import-require-alias/expected-page.css
+++ b/test/autotests/plugin/import-require-alias/expected-page.css
@@ -1,0 +1,33 @@
+/*********************************************************************/
+/* BEGIN "test/autotests/plugin/import-require-alias/variables.less" */
+/* END   "test/autotests/plugin/import-require-alias/variables.less" */
+/*********************************************************************/
+/****************************************************************/
+/* BEGIN "test/autotests/plugin/import-require-alias/main.less" */
+/* @import "~installed/mixins.less"; */
+/*-----------------------------------------------------------------------------------------*/
+/* + BEGIN "test/autotests/plugin/import-require-alias/node_modules/installed/mixins.less" */
+.bordered {
+  border-top: dotted 1px purple;
+  border-bottom: solid 2px purple;
+}
+/* + END   "test/autotests/plugin/import-require-alias/node_modules/installed/mixins.less" */
+/*-----------------------------------------------------------------------------------------*/
+.main {
+  color: red;
+  border-top: dotted 1px purple;
+  border-bottom: solid 2px purple;
+}
+/* END   "test/autotests/plugin/import-require-alias/main.less" */
+/****************************************************************/
+/*******************************************************************/
+/* BEGIN "test/autotests/plugin/import-require-alias/baz/baz.less" */
+/* @import "~installed/mixins.less"; (skipped, already imported) */
+.baz {
+  color: blue;
+  border-top: dotted 1px purple;
+  border-bottom: solid 2px purple;
+}
+/* END   "test/autotests/plugin/import-require-alias/baz/baz.less" */
+/*******************************************************************/
+

--- a/test/autotests/plugin/import-require-alias/foo/browser.json
+++ b/test/autotests/plugin/import-require-alias/foo/browser.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": [
+        "foo.less"
+    ]
+}

--- a/test/autotests/plugin/import-require-alias/foo/foo.less
+++ b/test/autotests/plugin/import-require-alias/foo/foo.less
@@ -1,0 +1,6 @@
+@import "~installed/mixins.less";
+
+.foo {
+    color: @foo-color;
+    .bordered;
+}

--- a/test/autotests/plugin/import-require-alias/main.less
+++ b/test/autotests/plugin/import-require-alias/main.less
@@ -1,0 +1,6 @@
+@import "~installed/mixins.less";
+
+.main {
+    color: @main-color;
+    .bordered;
+}

--- a/test/autotests/plugin/import-require-alias/node_modules/installed/mixins.less
+++ b/test/autotests/plugin/import-require-alias/node_modules/installed/mixins.less
@@ -1,0 +1,4 @@
+.bordered {
+    border-top: dotted 1px @borderColor;
+    border-bottom: solid 2px @borderColor;
+}

--- a/test/autotests/plugin/import-require-alias/node_modules/installed/style.less
+++ b/test/autotests/plugin/import-require-alias/node_modules/installed/style.less
@@ -1,0 +1,6 @@
+@import "mixins.less";
+@import "variables.less";
+
+.installed {
+    .bordered;
+}

--- a/test/autotests/plugin/import-require-alias/node_modules/installed/variables.less
+++ b/test/autotests/plugin/import-require-alias/node_modules/installed/variables.less
@@ -1,0 +1,1 @@
+@borderColor: purple;

--- a/test/autotests/plugin/import-require-alias/test.js
+++ b/test/autotests/plugin/import-require-alias/test.js
@@ -1,0 +1,43 @@
+var expect = require('chai').expect;
+var fs = require('fs');
+var path = require('path');
+
+exports.getLassoConfig = function(lassoLessPlugin) {
+    return {
+        fingerprintsEnabled: false,
+        bundlingEnabled: false,
+        urlPrefix: '/static',
+        plugins: [
+            {
+                plugin: lassoLessPlugin,
+                config: {}
+            }
+        ],
+        bundles: [
+            {
+                name: 'baz',
+                dependencies: [
+                    require.resolve('./baz/browser.json')
+                ]
+            }
+        ]
+    };
+};
+
+exports.getLassoOptions = function() {
+    return {
+        dependencies: [
+            require.resolve('./browser.json')
+        ]
+    };
+};
+
+
+
+exports.check = function(lassoPageResult, helpers) {
+    var outputFiles = lassoPageResult.getCSSFiles();
+    expect(outputFiles.length).to.equal(2);
+
+    helpers.compare(fs.readFileSync(outputFiles[0], { encoding: 'utf8' }), '-async.css');
+    helpers.compare(fs.readFileSync(outputFiles[1], { encoding: 'utf8' }), '-page.css');
+};

--- a/test/autotests/plugin/import-require-alias/variables.less
+++ b/test/autotests/plugin/import-require-alias/variables.less
@@ -1,0 +1,4 @@
+@main-color: red;
+@foo-color: green;
+@bar-color: blue;
+@borderColor: purple;


### PR DESCRIPTION
As the title says, currently to use Nodejs style `require` resolution with this plugin you must use `require: path`. This change adds support for the same syntax implemented in the [lasso webpack loader](https://github.com/webpack-contrib/less-loader#webpack-resolver) to increase compatibility between the two tools.